### PR TITLE
Adding a row of selectors to change the size of arrowheads

### DIFF
--- a/src/browser/modules/D3Visualization/components/Graph.tsx
+++ b/src/browser/modules/D3Visualization/components/Graph.tsx
@@ -28,7 +28,6 @@ import {
   StyledZoomHolder,
   StyledSvgWrapper,
   StyledZoomButton,
-  StyledSliderHolder,
   StyleInputDiv,
   StyleSubmitButton,
   StyleTextArea,
@@ -43,13 +42,12 @@ import graphView from '../lib/visualization/components/graphView'
 
 type State = any
 
-import { getShapeDef } from '../lib/visualization/utils/shapes'
 import { getPatternDashes } from '../lib/visualization/utils/pattern'
 import { connect } from 'react-redux'
 import { presetPaletteAction } from 'shared/modules/palette/palette'
 import { addFilterAction } from 'shared/modules/filters/filters'
 import { GlobalState } from 'shared/globalState'
-import { string } from 'prop-types'
+import { updateLayoutAction } from 'shared/modules/layout/layout'
 
 interface RelationshipLayout {
   arrowLayout: 'stripes' | 'segments' | 'separate'
@@ -464,6 +462,7 @@ export class Graph extends Component<any, State> {
                 onClick={() => {
                   if (this.state.featureExpressionLayout !== layout) {
                     const newLayout = relationshipLayouts[layout.items[0].id]
+                    this.props.updateLayoutAction(newLayout.arrowLayout)
                     log('change to ' + layout.display)
                     this.setState({
                       featureExpressionLayout: layout,
@@ -633,6 +632,7 @@ export const GraphComponent = connect(
     setDarkTheme: () => dispatch(presetPaletteAction('dark')),
     setLightCustomTheme: () => dispatch(presetPaletteAction('lightCustom')),
     setDarkCustomTheme: () => dispatch(presetPaletteAction('darkCustom')),
-    addFilterAction: (filter: string) => dispatch(addFilterAction(filter))
+    addFilterAction: (filter: string) => dispatch(addFilterAction(filter)),
+    updateLayoutAction: (layout: string) => dispatch(updateLayoutAction(layout))
   })
 )(Graph)

--- a/src/browser/modules/D3Visualization/components/GrassEditor.tsx
+++ b/src/browser/modules/D3Visualization/components/GrassEditor.tsx
@@ -41,6 +41,7 @@ import { Action, Dispatch } from 'redux'
 import PatternSelector from './PatternSelector'
 import { removeFilterAction } from 'shared/modules/filters/filters'
 import { PaletteState } from 'shared/modules/palette/palette'
+import { LayoutState } from 'shared/modules/layout/layout'
 
 type GrassEditorProps = {
   graphStyleData?: any
@@ -59,6 +60,7 @@ export class GrassEditorComponent extends Component<
   GrassEditorProps & {
     palette: PaletteState
     removeFilter: (value: string) => void
+    layout: LayoutState
   }
 > {
   graphStyle: any
@@ -356,25 +358,34 @@ export class GrassEditorComponent extends Component<
         color: styleForRelType.get('text-color-internal'),
         cursor: 'default'
       }
-      pickers = [
-        // this.colorPicker(styleForRelType.selector, styleForRelType, false),
-        this.widthPicker(
-          styleForRelType.selector,
-          styleForRelType,
-          'shaft-width'
-        ),
-        this.widthPicker(
-          styleForRelType.selector,
-          styleForRelType,
-          'head-width'
-        )
-        // this.captionPicker(
-        //   styleForRelType.selector,
-        //   styleForRelType,
-        //   this.props.selectedRelType.propertyKeys,
-        //   true
-        // )
-      ]
+      pickers =
+        this.props.layout !== 'separate'
+          ? [
+              // this.colorPicker(styleForRelType.selector, styleForRelType, false),
+              this.widthPicker(
+                styleForRelType.selector,
+                styleForRelType,
+                'shaft-width'
+              ),
+              this.widthPicker(
+                styleForRelType.selector,
+                styleForRelType,
+                'head-width'
+              )
+              // this.captionPicker(
+              //   styleForRelType.selector,
+              //   styleForRelType,
+              //   this.props.selectedRelType.propertyKeys,
+              //   true
+              // )
+            ]
+          : [
+              this.widthPicker(
+                styleForRelType.selector,
+                styleForRelType,
+                'head-width'
+              )
+            ]
       title = (
         <StyledTokenRelationshipType style={inlineStyle}>
           {this.props.selectedRelType.relType || '*'}
@@ -491,7 +502,8 @@ export class GrassEditorComponent extends Component<
 const mapStateToProps = (state: GlobalState) => ({
   graphStyleData: actions.getGraphStyleData(state),
   meta: state.meta,
-  palette: state.palette
+  palette: state.palette,
+  layout: state.layout
 })
 
 const mapDispatchToProps = (dispatch: Dispatch<Action>) => ({

--- a/src/browser/modules/D3Visualization/components/GrassEditor.tsx
+++ b/src/browser/modules/D3Visualization/components/GrassEditor.tsx
@@ -184,16 +184,15 @@ export class GrassEditorComponent extends Component<
     )
   }
 
-  widthPicker(selector: any, styleForItem: any) {
+  widthPicker(selector: any, styleForItem: any, property: string) {
     const widthSelectors = this.graphStyle
-      .defaultArrayWidths()
+      .defaultArrayWidths(property)
       .map((widthValue: any, i: any) => {
         const onClick = () => {
           this.updateStyle(selector, widthValue)
         }
         const style = { width: this.widths[i] }
-        const active =
-          styleForItem.get('shaft-width') === widthValue['shaft-width']
+        const active = styleForItem.get(property) === widthValue[property]
         return (
           <StyledPickerListItem key={toKeyString('width' + i)}>
             <StyledPickerSelector
@@ -204,10 +203,13 @@ export class GrassEditorComponent extends Component<
           </StyledPickerListItem>
         )
       })
+
     return (
-      <StyledInlineListItem key="width-picker">
+      <StyledInlineListItem key={`${property}-picker`}>
         <StyledInlineList>
-          <StyledInlineListItem>Line width:</StyledInlineListItem>
+          <StyledInlineListItem>
+            {property == 'shaft-width' ? 'Line width:' : 'Arrowhead size:'}
+          </StyledInlineListItem>
           {widthSelectors}
         </StyledInlineList>
       </StyledInlineListItem>
@@ -356,7 +358,16 @@ export class GrassEditorComponent extends Component<
       }
       pickers = [
         // this.colorPicker(styleForRelType.selector, styleForRelType, false),
-        this.widthPicker(styleForRelType.selector, styleForRelType)
+        this.widthPicker(
+          styleForRelType.selector,
+          styleForRelType,
+          'shaft-width'
+        ),
+        this.widthPicker(
+          styleForRelType.selector,
+          styleForRelType,
+          'head-width'
+        )
         // this.captionPicker(
         //   styleForRelType.selector,
         //   styleForRelType,

--- a/src/browser/modules/D3Visualization/graphStyle.ts
+++ b/src/browser/modules/D3Visualization/graphStyle.ts
@@ -38,7 +38,7 @@ export default function neoGraphStyle() {
     relationship: {
       color: 'var(--graph-color0)',
       'shaft-width': '5px', // Check if the link gets thicker
-      'head-width': '8px',
+      'head-width': '10px',
       'font-size': '14px',
       padding: '3px',
       'text-color-external': '#000000',

--- a/src/browser/modules/D3Visualization/graphStyle.ts
+++ b/src/browser/modules/D3Visualization/graphStyle.ts
@@ -38,6 +38,7 @@ export default function neoGraphStyle() {
     relationship: {
       color: 'var(--graph-color0)',
       'shaft-width': '5px', // Check if the link gets thicker
+      'head-width': '8px',
       'font-size': '14px',
       padding: '3px',
       'text-color-external': '#000000',
@@ -86,7 +87,7 @@ export default function neoGraphStyle() {
       'icon-code': 'k'
     }
   ]
-  const defaultArrayWidths = [
+  const defaultShaftWidths = [
     {
       'shaft-width': '1px'
     },
@@ -112,6 +113,33 @@ export default function neoGraphStyle() {
       'shaft-width': '38px'
     }
   ]
+  const defaultArrowheadWidths = [
+    {
+      'head-width': '3px'
+    },
+    {
+      'head-width': '5px'
+    },
+    {
+      'head-width': '8px'
+    },
+    {
+      'head-width': '10px'
+    },
+    {
+      'head-width': '13px'
+    },
+    {
+      'head-width': '18px'
+    },
+    {
+      'head-width': '23px'
+    }
+  ]
+  const defaultWidthsMapping = {
+    'shaft-width': defaultShaftWidths,
+    'head-width': defaultArrowheadWidths
+  }
   // const defaultColors = [
   //   {
   //     color: '#FFE081',
@@ -847,8 +875,10 @@ export default function neoGraphStyle() {
       return defaultIconCodes
     }
 
-    GraphStyle.prototype.defaultArrayWidths = function() {
-      return defaultArrayWidths
+    GraphStyle.prototype.defaultArrayWidths = function(
+      property: 'shaft-width' | 'head-width'
+    ) {
+      return defaultWidthsMapping[property]
     }
 
     GraphStyle.prototype.defaultColors = function() {

--- a/src/browser/modules/D3Visualization/lib/visualization/utils/pairwiseArcsRelationshipRouting.ts
+++ b/src/browser/modules/D3Visualization/lib/visualization/utils/pairwiseArcsRelationshipRouting.ts
@@ -225,7 +225,11 @@ export default class PairwiseArcsRelationshipRouting {
                 parseFloat(
                   this.style.forRelationship(relationship).get('shaft-width')
                 ) || 2
-              const headWidth = shaftWidth + 6
+              const arrowWidth =
+                parseFloat(
+                  this.style.forRelationship(relationship).get('head-width')
+                ) || 8
+              const headWidth = shaftWidth + arrowWidth
               const headHeight = headWidth
 
               if (nodePair.isLoop()) {

--- a/src/browser/modules/D3Visualization/lib/visualization/utils/straightArrow.ts
+++ b/src/browser/modules/D3Visualization/lib/visualization/utils/straightArrow.ts
@@ -49,6 +49,7 @@ export default class StraightArrow {
     const startArrow = startRadius
     const endShaft = startArrow + this.shaftLength
     const endArrow = startArrow + this.length
+
     const shaftRadius = shaftWidth / 2
     const headRadius = headWidth / 2
 
@@ -57,8 +58,9 @@ export default class StraightArrow {
       const hLength = headHeight
       const distance = Math.min(6, startRadius / colorCount)
       this.separateArrowWidth = distance * colorCount
-      const sRadius = distance * 0.25
-      const hRadius = distance * 0.4
+
+      const sRadius = distance * 0.3
+      const hRadius = distance * 0.5
       const offset = distance * (index - (colorCount - 1) / 2)
       const extraLength =
         endRadius - Math.sqrt(endRadius * endRadius - offset * offset)

--- a/src/shared/globalState.ts
+++ b/src/shared/globalState.ts
@@ -64,6 +64,7 @@ import {
 } from './modules/experimentalFeatures/experimentalFeaturesDuck'
 import { PaletteState } from './modules/palette/palette'
 import { FilterState } from './modules/filters/filters'
+import { LayoutState } from './modules/layout/layout'
 
 export interface GlobalState {
   [settings]: typeof settingsInitialState
@@ -89,4 +90,5 @@ export interface GlobalState {
   [guides]: GuideState
   palette: PaletteState
   filters: FilterState
+  layout: LayoutState
 }

--- a/src/shared/modules/layout/layout.ts
+++ b/src/shared/modules/layout/layout.ts
@@ -1,0 +1,23 @@
+const UPDATE_LAYOUT = 'layout/UPDATE'
+
+interface UpdateLayoutAction {
+  type: typeof UPDATE_LAYOUT
+  layout: string
+}
+
+export type LayoutState = string
+
+export function updateLayoutAction(layout: string): UpdateLayoutAction {
+  return { type: UPDATE_LAYOUT, layout }
+}
+
+export default function layoutReducer(
+  state: LayoutState = 'stripes',
+  action: UpdateLayoutAction
+): LayoutState {
+  if (action.type === UPDATE_LAYOUT) {
+    return action.layout
+  }
+
+  return state
+}

--- a/src/shared/rootReducer.ts
+++ b/src/shared/rootReducer.ts
@@ -68,6 +68,7 @@ import experimentalFeaturesReducer, {
 } from 'shared/modules/experimentalFeatures/experimentalFeaturesDuck'
 import { paletteReducer } from 'shared/modules/palette/palette'
 import filtersReducer from './modules/filters/filters'
+import layoutReducer from './modules/layout/layout'
 
 export default {
   [connections]: connectionsReducer,
@@ -92,5 +93,6 @@ export default {
   [guides]: guideReducer,
   [experimentalFeatures]: experimentalFeaturesReducer,
   palette: paletteReducer,
-  filters: filtersReducer
+  filters: filtersReducer,
+  layout: layoutReducer
 }


### PR DESCRIPTION
## Proposed Changes

When the user clicks on `Relationship Types` to customize the paths representation relationships between two nodes, I've added a row for `Arrowhead size`, similar to the `Line width` selector above, to let the user customize the size of the arrowheads. 

The default arrowhead size is set to be `8px` right now, which will look like the following:
![Screen Shot 2023-05-16 at 11 02 53 PM](https://github.com/toledorafael/neo4j-browser/assets/59714584/d0ddea62-445d-4443-8e0d-76e6576d9916)

## Additional Usability Improvement
When the user chooses "Individual links" as the `Layout`, it doesn't really make sense to make the width of each relationship route selectable. Thus I disabled the selector to change `Line Width` for "Individual links".   

https://github.com/toledorafael/neo4j-browser/assets/59714584/44e00354-774f-4f83-97db-72493b911939

## Demo
https://github.com/toledorafael/neo4j-browser/assets/59714584/5a574dce-3230-4ae8-97a0-ed3dbe081a20

